### PR TITLE
Manual formatting tweaks

### DIFF
--- a/api/src/main/java/jakarta/enterprise/context/ApplicationScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/ApplicationScoped.java
@@ -34,9 +34,8 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * </p>
  * <p>
  * While <code>ApplicationScoped</code> must be associated with the built-in application context required by the specification,
- * third-party extensions are
- * allowed to also associate it with their own context. Behavior described below is only related to the built-in application
- * context.
+ * third-party extensions are allowed to also associate it with their own context. Behavior described below is only related to
+ * the built-in application context.
  * </p>
  *
  * <p>
@@ -45,8 +44,7 @@ import jakarta.enterprise.util.AnnotationLiteral;
  *
  * <ul>
  * <li>during the <code>service()</code> method of any servlet in the web application, during the <code>doFilter()</code> method
- * of any
- * servlet filter and when the container calls any <code>ServletContextListener</code>, <code>HttpSessionListener</code>,
+ * of any servlet filter and when the container calls any <code>ServletContextListener</code>, <code>HttpSessionListener</code>,
  * <code>AsyncListener</code> or <code>ServletRequestListener</code>,</li>
  * <li>during any Java EE web service invocation,</li>
  * <li>during any remote method invocation of any EJB, during any asynchronous method invocation of any EJB, during any call to
@@ -67,9 +65,8 @@ import jakarta.enterprise.util.AnnotationLiteral;
  *
  * <p>
  * An event with qualifier <code>@Initialized(ApplicationScoped.class)</code> is fired when the application context is
- * initialized
- * and an event with qualifier <code>@Destroyed(ApplicationScoped.class)</code> when the application context is destroyed.
- * The event payload is:
+ * initialized and an event with qualifier <code>@Destroyed(ApplicationScoped.class)</code> when the application context is
+ * destroyed. The event payload is:
  * </p>
  *
  * <ul>

--- a/api/src/main/java/jakarta/enterprise/context/ConversationScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/ConversationScoped.java
@@ -34,10 +34,8 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * </p>
  * <p>
  * While <code>ConversationScoped</code> must be associated with the built-in conversation context required by the
- * specification,
- * third-party extensions are
- * allowed to also associate it with their own context. Behavior described below is only related to the built-in conversation
- * context.
+ * specification, third-party extensions are allowed to also associate it with their own context. Behavior described below is
+ * only related to the built-in conversation context.
  * </p>
  * <p>
  * The conversation scope is active:
@@ -47,9 +45,8 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * </ul>
  * <p>
  * An event with qualifier <code>@Initialized(ConversationScoped.class)</code> is fired when the conversation context is
- * initialized
- * and an event with qualifier <code>@Destroyed(ConversationScoped.class)</code> is fired when the conversation is destroyed.
- * The event payload is:
+ * initialized and an event with qualifier <code>@Destroyed(ConversationScoped.class)</code> is fired when the conversation is
+ * destroyed. The event payload is:
  * </p>
  * <ul>
  * <li>the conversation id if the conversation context is destroyed and is not associated with a current Servlet request,
@@ -68,11 +65,9 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * <li>The container provides a filter with the name "CDI Conversation Filter", which may be mapped in <code>web.xml</code>,
  * allowing the user alter when the conversation is associated with the servlet request. If this filter is not mapped in any
  * <code>web.xml</code> in the application, the conversation associated with a Servlet request is determined at the beginning of
- * the
- * request before calling any <code>service()</code> method of any servlet in the web application, calling the
- * <code>doFilter()</code>
- * method of any servlet filter in the web application and before the container calls any <code>ServletRequestListener</code> or
- * <code>AsyncListener</code> in the web application.</li>
+ * the request before calling any <code>service()</code> method of any servlet in the web application, calling the
+ * <code>doFilter()</code> method of any servlet filter in the web application and before the container calls any
+ * <code>ServletRequestListener</code> or <code>AsyncListener</code> in the web application.</li>
  * </ul>
  *
  *
@@ -113,15 +108,13 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * any faces request (JSF form submission) that originates from that rendered page.</li>
  * <li>The long-running conversation context associated with a request that results in a JSF redirect (a redirect resulting from
  * a navigation rule or JSF <code>NavigationHandler</code>) is automatically propagated to the resulting non-faces request, and
- * to any other
- * subsequent request to the same URL. This is accomplished via use of a request parameter named <code>cid</code> containing the
- * unique identifier of the conversation.</li>
+ * to any other subsequent request to the same URL. This is accomplished via use of a request parameter named <code>cid</code>
+ * containing the unique identifier of the conversation.</li>
  * </ul>
  *
  * <p>
  * When no conversation is propagated to a Servlet request, or if a request parameter named <code>conversationPropagation</code>
- * has
- * the value <code>none</code> the request is associated with a new transient conversation.
+ * has the value <code>none</code> the request is associated with a new transient conversation.
  * All long-running conversations are scoped to a particular HTTP servlet session and may not cross session boundaries.
  * In the following cases, a propagated long-running conversation cannot be restored and re-associated with the request:
  * </p>

--- a/api/src/main/java/jakarta/enterprise/context/Dependent.java
+++ b/api/src/main/java/jakarta/enterprise/context/Dependent.java
@@ -58,13 +58,13 @@ import jakarta.inject.Scope;
  * </ul>
  *
  * <p>
- * Every invocation of the {@link Context#get(Contextual, CreationalContext)} operation of the
- * context object for the <code>@Dependent</code> scope returns a new instance of the given bean.
+ * Every invocation of the {@link Context#get(Contextual, CreationalContext)} operation of the context object for the
+ * <code>@Dependent</code> scope returns a new instance of the given bean.
  * </p>
  *
  * <p>
- * Every invocation of the {@link Context#get(Contextual)} operation of the context object for the
- * <code>@Dependent</code> scope returns a null value.
+ * Every invocation of the {@link Context#get(Contextual)} operation of the context object for the <code>@Dependent</code> scope
+ * returns a null value.
  * </p>
  *
  * <p>
@@ -73,19 +73,17 @@ import jakarta.inject.Scope;
  *
  * <p>
  * Many instances of beans with scope <code>@Dependent</code> belong to some other bean or Java EE component class instance and
- * are
- * called dependent objects.
+ * are called dependent objects.
  * </p>
  *
  * <ul>
  * <li>Instances of decorators and interceptors are dependent objects of the bean instance they decorate.</li>
  * <li>An instance of a bean with scope <code>@Dependent</code> injected into a field, bean constructor or initializer method is
- * a
- * dependent object of the bean or Java EE component class instance into which it was injected.</li>
+ * a dependent object of the bean or Java EE component class instance into which it was injected.</li>
  * <li>An instance of a bean with scope <code>@Dependent</code> injected into a producer method is a dependent object of the
  * producer method bean instance that is being produced.</li>
- * <li>An instance of a bean with scope <code>@Dependent</code> obtained by direct invocation of an
- * {@link Instance} is a dependent object of the instance of {@link Instance}.</li>
+ * <li>An instance of a bean with scope <code>@Dependent</code> obtained by direct invocation of an {@link Instance} is a
+ * dependent object of the instance of {@link Instance}.</li>
  * </ul>
  *
  * <p>

--- a/api/src/main/java/jakarta/enterprise/context/RequestScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/RequestScoped.java
@@ -34,9 +34,8 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * </p>
  * <p>
  * While <code>RequestScoped</code> must be associated with the built-in request context required by the specification,
- * third-party extensions are
- * allowed to also associate it with their own context. Behavior described below is only related to the built-in request
- * context.
+ * third-party extensions are allowed to also associate it with their own context. Behavior described below is only related to
+ * the built-in request context.
  * </p>
  *
  * <p>
@@ -45,8 +44,8 @@ import jakarta.enterprise.util.AnnotationLiteral;
  *
  * <ul>
  * <li>during the <code>service()</code> method of any servlet in the web application, during the <code>doFilter()</code> method
- * of any
- * servlet filter and when the container calls any <code>ServletRequestListener</code> or <code>AsyncListener</code>,</li>
+ * of any servlet filter and when the container calls any <code>ServletRequestListener</code> or
+ * <code>AsyncListener</code>,</li>
  * <li>during any Java EE web service invocation,</li>
  * <li>during any remote method invocation of any EJB, during any asynchronous method invocation of any EJB, during any call to
  * an EJB timeout method and during message delivery to any EJB message-driven bean, and</li>
@@ -61,18 +60,16 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * <li>at the end of the servlet request, after the <code>service()</code> method, all <code>doFilter()</code> methods, and all
  * <code>requestDestroyed()</code> and <code>onComplete()</code> notifications return,</li>
  * <li>after the web service invocation completes,</li>
- * <li>after the EJB remote method invocation, asynchronous method invocation, timeout or message delivery completes if it
- * did not already exist when the invocation occurred, or</li>
+ * <li>after the EJB remote method invocation, asynchronous method invocation, timeout or message delivery completes if it did
+ * not already exist when the invocation occurred, or</li>
  * <li>after the <code>@PostConstruct</code> callback completes, if it did not already exist when the
- * <code>@PostConstruct</code>
- * callback occurred.</li>
+ * <code>@PostConstruct</code> callback occurred.</li>
  * </ul>
  *
  * <p>
  * An event with qualifier <code>@Initialized(RequestScoped.class)</code> is fired when the request context is initialized and
- * an
- * event
- * with qualifier <code>@Destroyed(RequestScoped.class)</code> when the request context is destroyed. The event payload is:
+ * an event with qualifier <code>@Destroyed(RequestScoped.class)</code> when the request context is destroyed. The event payload
+ * is:
  * </p>
  *
  * <ul>

--- a/api/src/main/java/jakarta/enterprise/context/SessionScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/SessionScoped.java
@@ -34,9 +34,8 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * </p>
  * <p>
  * While <code>SessionScoped</code> must be associated with the built-in session context required by the specification,
- * third-party extensions are
- * allowed to also associate it with their own context. Behavior described below is only related to the built-in session
- * context.
+ * third-party extensions are allowed to also associate it with their own context. Behavior described below is only related to
+ * the built-in session context.
  * </p>
  * <p>
  * The session scope is active:
@@ -58,18 +57,14 @@ import jakarta.enterprise.util.AnnotationLiteral;
  *
  * <ul>
  * <li>when the HTTPSession times out, after all <code>HttpSessionListeners</code> have been called, or</li>
- * <li>at the very end of
- * any request in which <code>invalidate()</code> was called, after all filters and <code>ServletRequestListeners</code> have
- * been
- * called.</Li>
+ * <li>at the very end of any request in which <code>invalidate()</code> was called, after all filters and
+ * <code>ServletRequestListeners</code> have been called.</Li>
  * </ul>
  *
  * <p>
  * An event with qualifier <code>@Initialized(SessionScoped.class)</code> is fired when the session context is initialized and
- * an
- * event
- * with qualifier <code>@Destroyed(SessionScoped.class)</code> when the session context is destroyed. The event payload is
- * the <code>HttpSession</code>
+ * an event with qualifier <code>@Destroyed(SessionScoped.class)</code> when the session context is destroyed. The event payload
+ * is the <code>HttpSession</code>
  *
  * <p>
  * CDI Lite implementations are not required to provide support for the session scope.

--- a/api/src/main/java/jakarta/enterprise/event/TransactionPhase.java
+++ b/api/src/main/java/jakarta/enterprise/event/TransactionPhase.java
@@ -77,9 +77,9 @@ public enum TransactionPhase {
      * </p>
      * <p>
      * Transactional observer will be notified will also get invoked if there is no transaction in progress, or the transaction
-     * is in progress,
-     * but {@code jakarta.transaction.Synchronization} callback cannot be registered due to the transaction being already
-     * marked for rollback or in state where {@code jakarta.transaction.Synchronization} callbacks cannot be registered.
+     * is in progress, but {@code jakarta.transaction.Synchronization} callback cannot be registered due to the transaction
+     * being already marked for rollback or in state where {@code jakarta.transaction.Synchronization} callbacks cannot be
+     * registered.
      * </p>
      */
     AFTER_FAILURE,

--- a/api/src/main/java/jakarta/enterprise/inject/Alternative.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Alternative.java
@@ -47,8 +47,8 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * <p>
  * By default, a bean archive has no selected alternatives. An alternative must be explicitly declared using the
  * <code>&lt;alternatives&gt;</code> element of the <code>beans.xml</code> file of the bean archive. The
- * <code>&lt;alternatives&gt;</code>
- * element contains a list of bean classes and stereotypes. An alternative is selected for the bean archive if either:
+ * <code>&lt;alternatives&gt;</code> element contains a list of bean classes and stereotypes. An alternative is selected for the
+ * bean archive if either:
  * </p>
  *
  * <ul>

--- a/api/src/main/java/jakarta/enterprise/inject/Instance.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Instance.java
@@ -61,8 +61,7 @@ import jakarta.inject.Provider;
  * </pre>
  *
  * <p>
- * Or, the {@link Any &#064;Any} qualifier may be used, allowing the application to specify qualifiers
- * dynamically:
+ * Or, the {@link Any &#064;Any} qualifier may be used, allowing the application to specify qualifiers dynamically:
  * </p>
  *
  * <pre>
@@ -82,10 +81,8 @@ import jakarta.inject.Provider;
  *
  * <p>
  * The inherited {@link jakarta.inject.Provider#get()} method returns a contextual references for the unique bean that matches
- * the
- * required type and required qualifiers and is eligible for injection into the class into which the parent
- * <code>Instance</code>
- * was injected, or throws an {@link UnsatisfiedResolutionException} or
+ * the required type and required qualifiers and is eligible for injection into the class into which the parent
+ * <code>Instance</code> was injected, or throws an {@link UnsatisfiedResolutionException} or
  * {@link AmbiguousResolutionException}.
  * </p>
  *
@@ -126,8 +123,7 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      * @param qualifiers the additional required qualifiers
      * @return the child <code>Instance</code>
      * @throws IllegalArgumentException if passed two instances of the same non repeating qualifier type, or an instance of an
-     *         annotation that
-     *         is not a qualifier type
+     *         annotation that is not a qualifier type
      * @throws IllegalStateException if the container is already shutdown
      */
     Instance<T> select(Annotation... qualifiers);
@@ -142,8 +138,7 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      * @param qualifiers the additional required qualifiers
      * @return the child <code>Instance</code>
      * @throws IllegalArgumentException if passed two instances of the same non repeating qualifier type, or an instance of an
-     *         annotation that
-     *         is not a qualifier type
+     *         annotation that is not a qualifier type
      * @throws IllegalStateException if the container is already shutdown
      */
     <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers);
@@ -158,8 +153,7 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      * @param qualifiers the additional required qualifiers
      * @return the child <code>Instance</code>
      * @throws IllegalArgumentException if passed two instances of the same non repeating qualifier type, or an instance of an
-     *         annotation that
-     *         is not a qualifier type
+     *         annotation that is not a qualifier type
      * @throws IllegalStateException if the container is already shutdown
      */
     <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers);
@@ -195,16 +189,15 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      * </p>
      *
      * @return <code>true</code> if there is more than one bean that matches the required type and qualifiers and is eligible
-     *         for
-     *         injection into the class into which the parent <code>Instance</code> was injected, or <code>false</code>
+     *         for injection into the class into which the parent <code>Instance</code> was injected, or <code>false</code>
      *         otherwise.
      */
     boolean isAmbiguous();
 
     /**
      * <p>
-     * Determines if there is exactly one bean that matches the required type and qualifiers and is eligible for injection
-     * into the class into which the parent <code>Instance</code> was injected.
+     * Determines if there is exactly one bean that matches the required type and qualifiers and is eligible for injection into
+     * the class into which the parent <code>Instance</code> was injected.
      * </p>
      *
      * @since 2.0
@@ -236,8 +229,8 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
     void destroy(T instance);
 
     /**
-     * Obtains an initialized contextual reference handle for a bean that has the required type and qualifiers and is
-     * eligible for injection. Throws exceptions if there is no such bean or more than one.
+     * Obtains an initialized contextual reference handle for a bean that has the required type and qualifiers and is eligible
+     * for injection. Throws exceptions if there is no such bean or more than one.
      *
      * <p>
      * The contextual reference is obtained lazily, i.e. when first needed.
@@ -251,8 +244,7 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
 
     /**
      * Allows iterating over contextual reference handles for all beans that have the required type and required qualifiers and
-     * are eligible
-     * for injection.
+     * are eligible for injection.
      *
      * <p>
      * Note that the returned {@link Iterable} is stateless. Therefore, each {@link Iterable#iterator()} produces a new set of
@@ -275,8 +267,8 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
     /**
      * This interface represents a contextual reference handle.
      * <p>
-     * Allows to inspect the metadata of the relevant bean before resolving its contextual reference and also to destroy
-     * the underlying contextual instance.
+     * Allows to inspect the metadata of the relevant bean before resolving its contextual reference and also to destroy the
+     * underlying contextual instance.
      * </p>
      *
      * @author Matej Novotny
@@ -290,8 +282,8 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
          * @return the contextual reference
          * @see Instance#get()
          * @throws IllegalStateException If the producing {@link Instance} does not exist
-         * @throws IllegalStateException If invoked on {@link Handle} that previously successfully destroyed its
-         *         underlying contextual reference
+         * @throws IllegalStateException If invoked on {@link Handle} that previously successfully destroyed its underlying
+         *         contextual reference
          */
         T get();
 

--- a/api/src/main/java/jakarta/enterprise/inject/Specializes.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Specializes.java
@@ -43,22 +43,18 @@ import jakarta.enterprise.util.AnnotationLiteral;
  *
  * <p>
  * If the second bean has a name, the bean may not declare a name using {@link jakarta.inject.Named &#064;Named}. Furthermore,
- * the
- * bean must have all the bean types of the second bean.
+ * the bean must have all the bean types of the second bean.
  * </p>
  *
  * <ul>
  * <li>If a bean class of a managed bean is annotated <code>&#064;Specializes</code> , then the bean class must directly extend
- * the
- * bean class of a second managed bean. Then the first managed bean directly specializes the second managed bean.</li>
+ * the bean class of a second managed bean. Then the first managed bean directly specializes the second managed bean.</li>
  *
  * <li>If a bean class of a session bean is annotated <code>&#064;Specializes</code> , then the bean class must directly extend
- * the
- * bean class of a second session bean. Then the first session bean directly specializes the second session bean.</li>
+ * the bean class of a second session bean. Then the first session bean directly specializes the second session bean.</li>
  *
  * <li>If a producer method is annotated <code>&#064;Specializes</code>, then it must be non-static and directly override
- * another
- * producer method. Then the first producer method directly specializes the second producer method.</li>
+ * another producer method. Then the first producer method directly specializes the second producer method.</li>
  * </ul>
  *
  * <p>

--- a/api/src/main/java/jakarta/enterprise/inject/Stereotype.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Stereotype.java
@@ -90,8 +90,7 @@ import java.lang.annotation.Target;
  *
  * <p>
  * A stereotype may declare an empty {@link jakarta.inject.Named &#064;Named} annotation, which specifies that every bean with
- * the
- * stereotype has a defaulted name when a name is not explicitly specified by the bean.
+ * the stereotype has a defaulted name when a name is not explicitly specified by the bean.
  * </p>
  *
  * <pre>
@@ -107,8 +106,8 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * <p>
- * A stereotype may declare an {@link Alternative &#064;Alternative} annotation, which specifies that
- * every bean with the stereotype is an alternative.
+ * A stereotype may declare an {@link Alternative &#064;Alternative} annotation, which specifies that every bean with the
+ * stereotype is an alternative.
  * </p>
  *
  * <pre>
@@ -121,8 +120,8 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * <p>
- * A stereotype may declare a {@link jakarta.annotation.Priority &#064;Priority} annotation, which specifies that
- * every bean with the stereotype is enabled and has given priority.
+ * A stereotype may declare a {@link jakarta.annotation.Priority &#064;Priority} annotation, which specifies that every bean
+ * with the stereotype is enabled and has given priority.
  * </p>
  *
  * <pre>

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SecurityActions.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SecurityActions.java
@@ -26,6 +26,7 @@ final class SecurityActions {
 
     static <T> ServiceLoader<T> loadService(Class<T> service, ClassLoader classLoader) {
         return AccessController.doPrivileged(
-                (PrivilegedAction<ServiceLoader<T>>) () -> ServiceLoader.load(service, classLoader));
+                (PrivilegedAction<ServiceLoader<T>>) () -> ServiceLoader.load(service, classLoader)
+        );
     }
 }

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AfterTypeDiscovery.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AfterTypeDiscovery.java
@@ -65,15 +65,13 @@ public interface AfterTypeDiscovery {
 
     /**
      * <p>
-     * Adds a given {@link AnnotatedType} to the set of types which will be scanned during bean
-     * discovery.
+     * Adds a given {@link AnnotatedType} to the set of types which will be scanned during bean discovery.
      * </p>
      *
      * <p>
      * Thanks to the id parameter, this method allows multiple annotated types, based on the same underlying type, to be
-     * defined. {@link AnnotatedType}s
-     * discovered by the container use the fully qualified class name of {@link AnnotatedType#getJavaClass()} to identify the
-     * type.
+     * defined. {@link AnnotatedType}s discovered by the container use the fully qualified class name of
+     * {@link AnnotatedType#getJavaClass()} to identify the type.
      * </p>
      *
      * <p>
@@ -89,16 +87,15 @@ public interface AfterTypeDiscovery {
 
     /**
      * <p>
-     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link AnnotatedType} and
-     * add it to the set of types which will be scanned during bean discovery at the end of the observer invocation.
-     * Calling this method multiple times will return a new AnnotatedTypeConfigurator.
+     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link AnnotatedType} and add it to the set of types
+     * which will be scanned during bean discovery at the end of the observer invocation. Calling this method multiple times
+     * will return a new AnnotatedTypeConfigurator.
      * </p>
      *
      * <p>
      * Thanks to the id parameter, this method allows multiple annotated types, based on the same underlying type, to be
-     * defined. {@link AnnotatedType}s
-     * discovered by the container use the fully qualified class name of {@link AnnotatedType#getJavaClass()} to identify the
-     * type.
+     * defined. {@link AnnotatedType}s discovered by the container use the fully qualified class name of
+     * {@link AnnotatedType#getJavaClass()} to identify the type.
      * </p>
      *
      * <p>

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
@@ -238,8 +238,7 @@ public interface BeanContainer {
      * Obtains an {@link Instance} object to access to beans instances.
      * <p>
      * The returned <code>Instance</code> object can only access instances of beans that are available for injection in the
-     * module
-     * or library containing the class into which the <code>BeanManager</code>/<code>BeanContainer</code> was injected
+     * module or library containing the class into which the <code>BeanManager</code>/<code>BeanContainer</code> was injected
      * or, in the Jakarta EE environment, the Jakarta EE component from whose JNDI environment namespace the
      * <code>BeanContainer</code> was obtained, according to the rules of typesafe resolution.
      * <p>

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanManager.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanManager.java
@@ -38,8 +38,8 @@ import jakarta.enterprise.util.Nonbinding;
  * </p>
  *
  * <p>
- * In CDI Lite environment, applications may obtain a {@code BeanManager}, but invoking methods that are not inherited
- * from {@link BeanContainer} results in non-portable behavior.
+ * In CDI Lite environment, applications may obtain a {@code BeanManager}, but invoking methods that are not inherited from
+ * {@link BeanContainer} results in non-portable behavior.
  * </p>
  *
  * <p>
@@ -53,8 +53,7 @@ import jakarta.enterprise.util.Nonbinding;
  *
  * <p>
  * Java EE components may obtain an instance of <code>BeanManager</code> from {@linkplain javax.naming JNDI} by looking up the
- * name
- * {@code java:comp/BeanManager}.
+ * name {@code java:comp/BeanManager}.
  * </p>
  *
  * <p>
@@ -236,10 +235,8 @@ public interface BeanManager extends BeanContainer {
     /**
      * Returns a wrapper {@link jakarta.el.ExpressionFactory} that delegates {@link jakarta.el.MethodExpression} and
      * {@link jakarta.el.ValueExpression} creation to the given {@link jakarta.el.ExpressionFactory}. When a Unified EL
-     * expression
-     * is evaluated using a {@link jakarta.el.MethodExpression} or {@link jakarta.el.ValueExpression} returned by the wrapper
-     * {@link jakarta.el.ExpressionFactory}, the container handles destruction of objects with scope
-     * {@link Dependent}.
+     * expression is evaluated using a {@link jakarta.el.MethodExpression} or {@link jakarta.el.ValueExpression} returned by the
+     * wrapper {@link jakarta.el.ExpressionFactory}, the container handles destruction of objects with scope {@link Dependent}.
      *
      * @deprecated use {@code ELAwareBeanManager}, this method will be removed in CDI 5.0
      * @param expressionFactory the {@link jakarta.el.ExpressionFactory} to wrap
@@ -343,8 +340,7 @@ public interface BeanManager extends BeanContainer {
      * The {@link InjectionTarget} creates and destroys instances of the bean, performs dependency injection and lifecycle
      * callbacks, and determines the return value of {@link Bean#getInjectionPoints()}. The {@link InjectionTarget} is obtained
      * from the {@link InjectionTargetFactory}. {@link #getInjectionTargetFactory(AnnotatedType)} allows use of a container
-     * created
-     * {@link InjectionTarget}.
+     * created {@link InjectionTarget}.
      * </p>
      *
      * @param <T> the type

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeforeBeanDiscovery.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeforeBeanDiscovery.java
@@ -142,15 +142,13 @@ public interface BeforeBeanDiscovery {
 
     /**
      * <p>
-     * Adds a given {@link AnnotatedType} to the set of types which will be scanned during bean
-     * discovery.
+     * Adds a given {@link AnnotatedType} to the set of types which will be scanned during bean discovery.
      * </p>
      *
      * <p>
      * Thanks to the id parameter, this method allows multiple annotated types, based on the same underlying type, to be
-     * defined. {@link AnnotatedType}s
-     * discovered by the container use the fully qualified class name of {@link AnnotatedType#getJavaClass()} to identify the
-     * type.
+     * defined. {@link AnnotatedType}s discovered by the container use the fully qualified class name of
+     * {@link AnnotatedType#getJavaClass()} to identify the type.
      * </p>
      *
      * <p>

--- a/api/src/main/java/jakarta/enterprise/inject/spi/InjectionPoint.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/InjectionPoint.java
@@ -31,8 +31,7 @@ import jakarta.enterprise.inject.Produces;
  * <p>
  * Provides access to metadata about an injection point. May represent an {@linkplain jakarta.inject.Inject injected field} or a
  * parameter of a {@linkplain jakarta.inject.Inject bean constructor}, {@linkplain jakarta.inject.Inject initializer method},
- * {@linkplain Produces producer method}, {@linkplain Disposes disposer method}
- * or {@linkplain Observes observer method}.
+ * {@linkplain Produces producer method}, {@linkplain Disposes disposer method} or {@linkplain Observes observer method}.
  * </p>
  *
  * <p>
@@ -42,15 +41,13 @@ import jakarta.enterprise.inject.Produces;
  * </p>
  *
  * <p>
- * Occasionally, a bean with scope {@link Dependent &#064;Dependent} needs to access metadata relating
- * to the object to which it belongs. The bean may inject an {@code InjectionPoint} representing the injection point into which
- * the bean was injected.
+ * Occasionally, a bean with scope {@link Dependent &#064;Dependent} needs to access metadata relating to the object to which it
+ * belongs. The bean may inject an {@code InjectionPoint} representing the injection point into which the bean was injected.
  * </p>
  *
  * <p>
  * For example, the following producer method creates injectable <code>Logger</code> s. The log category of a
- * <code>Logger</code>
- * depends upon the class of the object into which it is injected.
+ * <code>Logger</code> depends upon the class of the object into which it is injected.
  * </p>
  *
  * <pre>
@@ -61,8 +58,7 @@ import jakarta.enterprise.inject.Produces;
  * </pre>
  *
  * <p>
- * Only {@linkplain Dependent dependent} objects, may obtain information about the injection point to
- * which they belong.
+ * Only {@linkplain Dependent dependent} objects, may obtain information about the injection point to which they belong.
  * </p>
  *
  * @author Gavin King

--- a/api/src/main/java/jakarta/enterprise/inject/spi/InjectionTarget.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/InjectionTarget.java
@@ -50,8 +50,7 @@ public interface InjectionTarget<T> extends Producer<T> {
     /**
      * <p>
      * Calls the {@link jakarta.annotation.PostConstruct} callback, if it exists, according to the semantics required by the
-     * Java
-     * EE platform specification.
+     * Java EE platform specification.
      * </p>
      *
      * @param instance The instance on which to invoke the {@link jakarta.annotation.PostConstruct} method
@@ -61,8 +60,7 @@ public interface InjectionTarget<T> extends Producer<T> {
     /**
      * <p>
      * Calls the {@link jakarta.annotation.PreDestroy} callback, if it exists, according to the semantics required by the Java
-     * EE
-     * platform specification.
+     * EE platform specification.
      * </p>
      *
      * @param instance The instance on which to invoke the {@link jakarta.annotation.PreDestroy} method

--- a/api/src/main/java/jakarta/enterprise/inject/spi/InjectionTargetFactory.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/InjectionTargetFactory.java
@@ -25,8 +25,8 @@ import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
  *
  * <p>
  * The {@link InjectionTargetFactory} obtained from {@link BeanManager#getInjectionTargetFactory(AnnotatedType)} is capable of
- * providing
- * container created injection targets. This factory can be wrapped to add behavior to container created injection targets.
+ * providing container created injection targets. This factory can be wrapped to add behavior to container created injection
+ * targets.
  * </p>
  *
  * <p>

--- a/api/src/main/java/jakarta/enterprise/inject/spi/InjectionTargetFactory.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/InjectionTargetFactory.java
@@ -39,8 +39,8 @@ import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
  *
  *     public &lt;T&gt; InjectionTarget&lt;T&gt; createInjectionTarget(Bean&lt;T&gt; bean) {
  *         return new WrappingInjectionTarget&lt;T&gt;(
- *                 beanManager.getInjectionTargetFactory(myBeanAnnotatedType).createInjectionTarget(
- *                         bean));
+ *                 beanManager.getInjectionTargetFactory(myBeanAnnotatedType)
+ *                         .createInjectionTarget(bean));
  *     }
  * });
  * </pre>

--- a/api/src/main/java/jakarta/enterprise/inject/spi/InterceptionFactory.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/InterceptionFactory.java
@@ -37,8 +37,8 @@ import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
  *
  *     BeanManager bm;
  *
- *     public MyBean(BeanManager bm){
- *     this.bm=bm;
+ *     public MyCustomBean(BeanManager bm) {
+ *         this.bm = bm;
  *     }
  *
  *     public MyClass create(CreationalContext&lt;MyClass&gt; creationalContext) {

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ObserverMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ObserverMethod.java
@@ -148,8 +148,7 @@ public interface ObserverMethod<T> extends Prioritized {
      * </p>
      *
      * @return returns <code>true</code> if the method is an asynchronous observer method (i.e. defined with
-     *         {@link ObservesAsync}),
-     *         otherwise returns <code>false</code>
+     *         {@link ObservesAsync}), otherwise returns <code>false</code>
      *
      */
     public default boolean isAsync() {

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessInjectionPoint.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessInjectionPoint.java
@@ -30,8 +30,7 @@ import jakarta.enterprise.inject.spi.configurator.InjectionPointConfigurator;
  * {@link #setInjectionPoint(InjectionPoint)} or {@link #configureInjectionPoint()}.
  * If both methods are called within an observer notification an {@link IllegalStateException} is thrown.
  * The container must use the final value of this property, after all observers have been called, he container must use the
- * final
- * value of this property, after all observers have been called, whenever it performs injection upon the injection point.
+ * final value of this property, after all observers have been called, whenever it performs injection upon the injection point.
  * </p>
  * <p>
  * If any observer method of a {@code ProcessInjectionPoint} event throws an exception, the exception is treated as a definition

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessObserverMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessObserverMethod.java
@@ -33,8 +33,7 @@ import jakarta.enterprise.inject.spi.configurator.ObserverMethodConfigurator;
  * {@link #setObserverMethod(ObserverMethod)} or {@link #configureObserverMethod()}.
  * If both methods are called within an observer notification an {@link IllegalStateException} is thrown.
  * The container must use the final value of this property, after all observers have been called, he container must use the
- * final
- * value of this property, after all observers have been called, whenever it performs observer resolution.
+ * final value of this property, after all observers have been called, whenever it performs observer resolution.
  * </p>
  * <p>
  * If any observer method of a {@code ProcessObserverMethod} event throws an exception, the exception is treated as a definition

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessSyntheticObserverMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessSyntheticObserverMethod.java
@@ -24,8 +24,7 @@ package jakarta.enterprise.inject.spi;
  * </p>
  * <p>
  * If any observer method of a {@code ProcessSyntheticObserverMethod} event throws an exception, the exception is treated as a
- * definition
- * error by the container.
+ * definition error by the container.
  * </p>
  *
  * <p>

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Producer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Producer.java
@@ -39,10 +39,8 @@ public interface Producer<T> {
      * </p>
      * <p>
      * If the {@code Producer} represents a class, this will invoke the constructor annotated {@link jakarta.inject.Inject} if
-     * it
-     * exists, or the constructor with no parameters otherwise. If the class has interceptors, <code>produce()</code> is
-     * responsible
-     * for building the interceptors and decorators of the instance.
+     * it exists, or the constructor with no parameters otherwise. If the class has interceptors, <code>produce()</code> is
+     * responsible for building the interceptors and decorators of the instance.
      * </p>
      * <p>
      * If the {@code Producer} represents a producer field or method, this will invoke the producer method on, or access the

--- a/api/src/main/java/jakarta/enterprise/inject/spi/SecurityActions.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/SecurityActions.java
@@ -35,6 +35,7 @@ final class SecurityActions {
 
     static <T> ServiceLoader<T> loadService(Class<T> service, ClassLoader classLoader) {
         return AccessController.doPrivileged(
-                (PrivilegedAction<ServiceLoader<T>>) () -> ServiceLoader.load(service, classLoader));
+                (PrivilegedAction<ServiceLoader<T>>) () -> ServiceLoader.load(service, classLoader)
+        );
     }
 }

--- a/api/src/main/java/jakarta/enterprise/inject/spi/WithAnnotations.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/WithAnnotations.java
@@ -33,10 +33,8 @@ import java.lang.annotation.Target;
  * If the {@link WithAnnotations} annotation is applied to a portable extension observer method, then only
  * {@link ProcessAnnotatedType} events for types which have at least one of the annotations specified are observed. The
  * annotation can appear on the annotated type, or on any member, or any parameter of any member of the annotated type, as
- * defined
- * in section <a href="https://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#alternative_metadata_sources">11.4 Alternative metadata
- * sources</a>.
- * The annotation may be applied as a meta-annotation on any annotation considered.
+ * defined in section <a href="https://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#alternative_metadata_sources">11.4 Alternative
+ * metadata sources</a>. The annotation may be applied as a meta-annotation on any annotation considered.
  *
  * <p>
  * CDI Lite implementations are not required to provide support for Portable Extensions.

--- a/api/src/main/java/jakarta/enterprise/util/Nonbinding.java
+++ b/api/src/main/java/jakarta/enterprise/util/Nonbinding.java
@@ -26,8 +26,7 @@ import java.lang.annotation.Target;
  * <p>
  * Excludes a member of an annotation type (such as a {@linkplain jakarta.inject.Qualifier qualifier type} or
  * {@linkplain jakarta.interceptor.InterceptorBinding interceptor binding type}) from consideration when the container compares
- * two annotation
- * instances.
+ * two annotation instances.
  * </p>
  *
  * <pre>

--- a/api/src/main/java/jakarta/enterprise/util/SecurityActions.java
+++ b/api/src/main/java/jakarta/enterprise/util/SecurityActions.java
@@ -39,7 +39,8 @@ final class SecurityActions {
                     (PrivilegedAction<?>) () -> {
                         method.setAccessible(true);
                         return null;
-                    });
+                    }
+            );
         } else {
             method.setAccessible(true);
         }
@@ -48,7 +49,8 @@ final class SecurityActions {
     static Method[] getDeclaredMethods(Class<?> clazz) {
         if (System.getSecurityManager() != null) {
             return AccessController.doPrivileged(
-                    (PrivilegedAction<Method[]>) () -> clazz.getDeclaredMethods());
+                    (PrivilegedAction<Method[]>) () -> clazz.getDeclaredMethods()
+            );
         } else {
             return clazz.getDeclaredMethods();
         }

--- a/el/src/main/java/jakarta/enterprise/inject/spi/el/ELAwareBeanManager.java
+++ b/el/src/main/java/jakarta/enterprise/inject/spi/el/ELAwareBeanManager.java
@@ -22,10 +22,8 @@ public interface ELAwareBeanManager extends BeanManager {
     /**
      * Returns a wrapper {@link jakarta.el.ExpressionFactory} that delegates {@link jakarta.el.MethodExpression} and
      * {@link jakarta.el.ValueExpression} creation to the given {@link jakarta.el.ExpressionFactory}. When a Unified EL
-     * expression
-     * is evaluated using a {@link jakarta.el.MethodExpression} or {@link jakarta.el.ValueExpression} returned by the wrapper
-     * {@link jakarta.el.ExpressionFactory}, the container handles destruction of objects with scope
-     * {@link Dependent}.
+     * expression is evaluated using a {@link jakarta.el.MethodExpression} or {@link jakarta.el.ValueExpression} returned by the
+     * wrapper {@link jakarta.el.ExpressionFactory}, the container handles destruction of objects with scope {@link Dependent}.
      *
      * @param expressionFactory the {@link jakarta.el.ExpressionFactory} to wrap
      * @return the wrapped {@link jakarta.el.ExpressionFactory}

--- a/ide-config/src/main/resources/cdi-format.xml
+++ b/ide-config/src/main/resources/cdi-format.xml
@@ -305,7 +305,7 @@
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="preserve_positions"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
 <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>


### PR DESCRIPTION
This PR makes the following additional formatting tweaks after the auto format plugin was added:

- Allow the closing parenthesis of a method invocation to be on the following line
  - Revert changes to `SecurityActions` classes where the original formatting is now permitted
- Manually break lines in the `InjectionTargetFactory` example for readability
- Fix the example code in `InterceptionFactory`
  - Also allows the formatter to format it properly
- Manually reflow some paragraphs throughout the Javadoc

You're welcome to drop or squash any of these changes as you see fit.